### PR TITLE
Fix pushing contracts with multiple arguments

### DIFF
--- a/app/controllers/v2/service_bindings_controller.rb
+++ b/app/controllers/v2/service_bindings_controller.rb
@@ -24,23 +24,42 @@ class V2::ServiceBindingsController < V2::BaseController
         Rails.logger.info("response to grab from: #{response}")
         host = response['credentials']['host']
         node_port = response['credentials']['ports']['8545/tcp']
-        require 'json'
-        unpacked = parameters.unpack('m')
-        parsedParameters = JSON.parse(unpacked[0])
-        Rails.logger.info("got params: #{parsedParameters}")
 
-        getContract = "wget #{parsedParameters["contract_url"]} -O /tmp/simple.sol 2>&1"
+        require 'json'
+        require 'securerandom'
+        unpacked = parameters.unpack('m')
+        parsed_parameters = JSON.parse(unpacked[0])
+        Rails.logger.info("got params: #{parsed_parameters}")
+
+        contract_id = SecureRandom.uuid
+        getContract = "wget #{parsed_parameters["contract_url"]} -O /tmp/#{contract_id}.sol 2>&1"
         Rails.logger.info("contract to get: #{getContract}")
         output = `#{getContract}`
         Rails.logger.info("got contract: #{output}")
 
         account = plan.container_manager.get_account(instance_guid)
         Rails.logger.info("got account: #{account}")
-        cmd = "solc --combined-json abi,bin /tmp/simple.sol > /tmp/simple.bin"
+        cmd = "solc --combined-json abi,bin /tmp/#{contract_id}.sol > /tmp/#{contract_id}.bin"
         output = `#{cmd}`
-        cmd = "node /var/vcap/packages/cf-containers-broker/pusher.js -p http://#{host}:#{node_port} -a #{account} -x foo /tmp/simple.bin 2>&1"
+
+        if !parsed_parameters.has_key?("contract_args")
+          parsed_parameters["contract_args"] = []
+        end
+
+        config = {
+          provider: "http://#{host}:#{node_port}",
+          password: "",
+          address: account,
+          args: parsed_parameters["contract_args"]
+        }
+
+        config_path = "/tmp/#{contract_id}.json"
+        File.open(config_path,"w") { |f| f.write(config.to_json) }
+
+        cmd = "node /var/vcap/packages/cf-containers-broker/pusher.js -c #{config_path} /tmp/#{contract_id}.bin 2>&1"
         Rails.logger.info("contract to apply to geth node: #{cmd}")
         output = `#{cmd}`
+        Rails.logger.info("cmd output: #{output}")
         cleaned = eval(output.gsub(/\n/, ''))
         response['credentials']['eth_node'] = cleaned
 

--- a/pusher.js
+++ b/pusher.js
@@ -1,18 +1,21 @@
 const CLI = require('cli-flags')
 const {flags, args} = CLI.parse({
   flags: {
-    'address': CLI.flags.string({char: 'a'}),
-    'password': CLI.flags.string({char: 'x'}),
-    'provider': CLI.flags.string({char: 'p'})
+    'config': CLI.flags.string({char: 'c'})
   },
   args: [
     {name: 'contract', required: true}
   ]
 })
 
-const address = flags.address
-const password = flags.password
-const provider = flags.provider
+var fs = require("fs");
+configContent = fs.readFileSync(flags.config);
+var config = JSON.parse(configContent);
+
+const address = config.address
+const password = config.password
+const provider = config.provider
+const cArgs = config.args
 const contractPath = args.contract
 
 result = {}
@@ -23,7 +26,7 @@ if (typeof web3 !== 'undefined') {
   // set the provider you want from Web3.providers
   web3 = new Web3(new Web3.providers.HttpProvider(provider));
 }
-
+const constructorArgs = convertArray(cArgs)
 
 if (provider == "") {
     console.log("no provider is provided")
@@ -48,6 +51,18 @@ fs.readFile(contractPath, {encoding: 'utf-8'}, function(err,data){
     }
 })
 
+function convertArray(argument){
+  var convertedArgs = []
+  argument.forEach(function(arg){
+    if (Array.isArray(arg)){
+      convertedArgs.push(convertArray(arg));
+    } else {
+      convertedArgs.push(web3.utils.asciiToHex(arg)) ;
+    }
+  });
+  return convertedArgs
+}
+
 function runDeployment(contract){
   web3.eth.personal.getAccounts()
   .then(data => {
@@ -64,7 +79,7 @@ function runDeployment(contract){
     var compiled = "0x" + contract.bin
     deploy = contractInterface.deploy({
       data: compiled,
-      arguments: [123]
+      arguments: constructorArgs
     });
     return deploy.estimateGas({from: address})
   })


### PR DESCRIPTION
Here is slightly different solution to the problem in https://github.com/nimakaviani/ethereum-container-broker/issues/23

- passes a configuration file to `pusher.js` to avoid the space madness in passing args to `cli-flags`
- randomizes the name of the generated contracts and configuration files so that deploying multiple contracts does not cause corruption in contract files